### PR TITLE
K8S-2157: Remove CNDB from CSB docs nav

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -26,5 +26,3 @@
 *** xref:reference/tools/cbsbctl.adoc[cbsbctl]
 
 * xref:release-notes.adoc[Release Notes]
-
-* xref:cloud-native-database::index.adoc[Go to Cloud-Native Database Documentation]


### PR DESCRIPTION
The Couchbase Cloud-Native Database link in the CSB docs nav will no longer be required after the docs-site is updated to collapse all of the Cloud-Native components into a single nav.