### PR TITLE
K8S-2157: Remove CNDB from CSB docs nav (1.1.x)

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -26,5 +26,3 @@
 *** xref:reference/tools/cbsbctl.adoc[cbsbctl]
 
 * xref:release-notes.adoc[Release Notes]
-
-* xref:cloud-native-database::index.adoc[Go to Cloud-Native Database Documentation]


### PR DESCRIPTION
This is a cherry-pick of https://github.com/couchbase/docs-service-broker/pull/14