### PR TITLE
K8S-2157: Remove CNDB from CSB docs nav (1.0.x)

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -24,5 +24,3 @@
 ** xref:reference/osb-api.adoc[Open Service Broker API Reference]
 
 * xref:release-notes.adoc[Release Notes]
-
-* xref:cloud-native-database::index.adoc[Go to Cloud-Native Database Documentation]


### PR DESCRIPTION
This is a cherry-pick of https://github.com/couchbase/docs-service-broker/pull/14